### PR TITLE
Added options to exclude filename extension and to exclude leading dot

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"publisher": "jakob101",
 	"galleryBanner": {
 		"color": "#373277",
-		"theme": "dark"	
+		"theme": "dark"
 	},
 	"engines": {
 		"vscode": "^0.10.1"
@@ -45,7 +45,17 @@
                     "items": {
                         "type": "string"
                     }
-				}
+				},
+                "relativePath.removeExtension": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Excludes the extension from the relative path url (Useful for systemjs imports)."
+                },
+                "relativePath.removeLeadingDot": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Removes the leading ./ character when the path is pointing to a parent folder."
+                }
 			}
 		}
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,138 +1,146 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode'; 
-var path = require('path');
-var Glob = require('glob').Glob;
+import * as vscode from "vscode";
+let path = require("path");
+let Glob = require("glob").Glob;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('The extension "RelativePath" is now active!'); 
-	const workspacePath: string = vscode.workspace.rootPath.replace(/\\/g, "/");
-	var configuration = vscode.workspace.getConfiguration("relativePath");
-	var editor = vscode.window.activeTextEditor;
-	let emptyItem: vscode.QuickPickItem = { label: "", description: "No files found" };
-	let items: string[] = null;
-	var myGlob = null;
-	let paused: boolean = false;
-		
-	function myActivate() {
-		
-		// Show loading info box
-		let info = vscode.window.showQuickPick([emptyItem], { matchOnDescription: false, placeHolder: "Finding files... Please wait. (Press escape to cancel)" });
-		info.then(
-			(value?: any) => {
-				myGlob.pause();
-				paused = true;
-			},
-			(rejected?: any) => {
-				myGlob.pause();
-				paused = true;
-			}
-		);
-		
-		//Search for files
-		if (paused) {
-			paused = false;
-			myGlob.resume();
-		} else {
-			myGlob = new Glob(workspacePath + "/**/*.*", 
-						{ ignore: configuration.get("ignore") }, 
-						function(err, files) {
-								if (err) {
-									return;
-								}
-								
-								items = files;
-								vscode.commands.executeCommand('extension.relativePath');
-					});	
-			myGlob.on("end", function() {
-				paused = false;	
-			})
-		}
-	}
-	
-	// Initialize activation
-	myActivate();
-	
-	// Watch for file system changes - as we're caching the searched files
-	let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("**/*.*");
-	watcher.ignoreChangeEvents = true;
-	
-	// Add a file on creation
-	watcher.onDidCreate((e: vscode.Uri) => {
-		items.push(e.fsPath.replace(/\\/g, "/"));
-	});
-	
-	// Remove a file on deletion
-	watcher.onDidDelete((e: vscode.Uri) => {
-		let item = e.fsPath.replace(/\\/g, "/");
-		let index = items.indexOf(item);
-		if (index > -1) {
-			items.splice(index, 1);
-		}
-	});
+    // Use the console to output diagnostic information (console.log) and errors (console.error)
+    // This line of code will only be executed once when your extension is activated
+    console.log("The extension \"RelativePath\" is now active!");
+    const workspacePath: string = vscode.workspace.rootPath.replace(/\\/g, "/");
+    let configuration: any = vscode.workspace.getConfiguration("relativePath");
+    let editor = vscode.window.activeTextEditor;
+    let emptyItem: vscode.QuickPickItem = { label: "", description: "No files found" };
+    let items: string[] = null;
+    let myGlob = null;
+    let paused: boolean = false;
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	var disposable = vscode.commands.registerCommand('extension.relativePath', () => {
-		// The code you place here will be executed every time your command is executed
-		
-		// If there's no file opened	
-		var editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showInformationMessage("You need to have a file opened.");	
-			return; // No open text editor
-		}
-		
-		// If we canceled the file search
-		if (paused) {
-			myActivate();
-			return;
-		}
-		
-		// If there are no items found
-		if (!items) {
-			return;
-		}
-		
-		showQuickPick(items);
-		
-		// Show dropdown editor
-		function showQuickPick(items: string[]): void {
-			if (items) {
-				let paths: vscode.QuickPickItem[] = items.map((val: string) => {
-					let item: vscode.QuickPickItem = { description: val.replace(workspacePath, ""), label: val.split("/").pop() };
-					return item;
-				});
-				
-				let pickResult: Thenable<vscode.QuickPickItem>;
-				pickResult = vscode.window.showQuickPick(paths, { matchOnDescription: true, placeHolder: "Filename" });
-				pickResult.then(returnRelativeLink);
-			} else {
-				vscode.window.showInformationMessage("No files to show.");
-			}
-		}
-		
-		// Get the picked item
-		function returnRelativeLink(item: vscode.QuickPickItem): void {
-			if (item) {
-				const targetPath = item.description;
-				const currentItemPath = editor.document.fileName.replace(/\\/g,"/").replace(workspacePath, "");
-				let relativeUrl: string = path.relative(currentItemPath, targetPath).replace(".", "").replace(/\\/g,"/");
-				vscode.window.activeTextEditor.edit(
-					(editBuilder: vscode.TextEditorEdit) => {
-						let position: vscode.Position = vscode.window.activeTextEditor.selection.end;
-						editBuilder.insert(position, relativeUrl);
-					}	
-				);
-			}
-		}
-	});
-	
-	context.subscriptions.push(disposable);
+    function myActivate() {
+
+        // Show loading info box
+        let info = vscode.window.showQuickPick([emptyItem], { matchOnDescription: false, placeHolder: "Finding files... Please wait. (Press escape to cancel)" });
+        info.then(
+            (value?: any) => {
+                myGlob.pause();
+                paused = true;
+            },
+            (rejected?: any) => {
+                myGlob.pause();
+                paused = true;
+            }
+        );
+
+        // Search for files
+        if (paused) {
+            paused = false;
+            myGlob.resume();
+        } else {
+            myGlob = new Glob(workspacePath + "/**/*.*",
+                { ignore: configuration.get("ignore") },
+                function(err, files) {
+                    if (err) {
+                        return;
+                    }
+
+                    items = files;
+                    vscode.commands.executeCommand("extension.relativePath");
+                });
+            myGlob.on("end", function() {
+                paused = false;
+            });
+        }
+    }
+
+    // Initialize activation
+    myActivate();
+
+    // Watch for file system changes - as we're caching the searched files
+    let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("**/*.*");
+    watcher.ignoreChangeEvents = true;
+
+    // Add a file on creation
+    watcher.onDidCreate((e: vscode.Uri) => {
+        items.push(e.fsPath.replace(/\\/g, "/"));
+    });
+
+    // Remove a file on deletion
+    watcher.onDidDelete((e: vscode.Uri) => {
+        let item = e.fsPath.replace(/\\/g, "/");
+        let index = items.indexOf(item);
+        if (index > -1) {
+            items.splice(index, 1);
+        }
+    });
+
+    // The command has been defined in the package.json file
+    // Now provide the implementation of the command with  registerCommand
+    // The commandId parameter must match the command field in package.json
+    let disposable = vscode.commands.registerCommand("extension.relativePath", () => {
+        // The code you place here will be executed every time your command is executed
+
+        // If there's no file opened
+        let editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage("You need to have a file opened.");
+            return; // No open text editor
+        }
+
+        // If we canceled the file search
+        if (paused) {
+            myActivate();
+            return;
+        }
+
+        // If there are no items found
+        if (!items) {
+            return;
+        }
+
+        showQuickPick(items);
+
+        // Show dropdown editor
+        function showQuickPick(items: string[]): void {
+            if (items) {
+                let paths: vscode.QuickPickItem[] = items.map((val: string) => {
+                    let item: vscode.QuickPickItem = { description: val.replace(workspacePath, ""), label: val.split("/").pop() };
+                    return item;
+                });
+
+                let pickResult: Thenable<vscode.QuickPickItem>;
+                pickResult = vscode.window.showQuickPick(paths, { matchOnDescription: true, placeHolder: "Filename" });
+                pickResult.then(returnRelativeLink);
+            } else {
+                vscode.window.showInformationMessage("No files to show.");
+            }
+        }
+
+        // Get the picked item
+        function returnRelativeLink(item: vscode.QuickPickItem): void {
+            if (item) {
+                const targetPath = item.description;
+                const currentItemPath = editor.document.fileName.replace(/\\/g, "/").replace(workspacePath, "");
+                let relativeUrl: string = path.relative(currentItemPath, targetPath).replace(".", "").replace(/\\/g, "/");
+
+                if (configuration.removeExtension) {
+                    relativeUrl = relativeUrl.substring(0, relativeUrl.lastIndexOf("."));
+                }
+                if (configuration.removeLeadingDot && relativeUrl.startsWith("./../")) {
+                    relativeUrl = relativeUrl.substring(2, relativeUrl.length);
+                }
+
+                vscode.window.activeTextEditor.edit(
+                    (editBuilder: vscode.TextEditorEdit) => {
+                        let position: vscode.Position = vscode.window.activeTextEditor.selection.end;
+                        editBuilder.insert(position, relativeUrl);
+                    }
+                );
+            }
+        }
+    });
+
+    context.subscriptions.push(disposable);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,8 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
     myActivate();
 
     // Watch for file system changes - as we're caching the searched files
-    let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("**/*.*");
-    watcher.ignoreChangeEvents = true;
+    let watcher: vscode.FileSystemWatcher = vscode.workspace.createFileSystemWatcher("**/*.*", false, true, false);
 
     // Add a file on creation
     watcher.onDidCreate((e: vscode.Uri) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es5",
 		"outDir": "out",
 		"noLib": true,
 		"sourceMap": true


### PR DESCRIPTION
The diff looks bigger than it is, I just formatted the code a little bit. We are using this extension with systemjs and we really love it. We found ourselves removing the extension of the files over and over again and the same for the leading ./ which is not necessary when going up on a path. 

I also updated some warnings that vscode showed when creating the file watcher.