### PR TITLE
Add excludeExtensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
                     "default": false,
                     "description": "Removes the leading ./ character when the path is pointing to a parent folder."
                 },
-                "relativePath.excludExtensions": {
+                "relativePath.excludedExtensions": {
                     "type": "array",
                     "default": [
                         ".js"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Removes the leading ./ character when the path is pointing to a parent folder."
+                },
+                "relativePath.excludExtensions": {
+                    "type": "array",
+                    "default": [
+                        ".js"
+                    ],
+                    "description": "An array of extensions to exclude from the relative path url (Useful for used with Webpack or when importing files of mixed types)"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import {window, workspace, commands, Disposable, 
-    ExtensionContext, StatusBarAlignment, StatusBarItem, 
+import {window, workspace, commands, Disposable,
+    ExtensionContext, StatusBarAlignment, StatusBarItem,
     TextDocument, QuickPickItem, FileSystemWatcher, Uri,
     TextEditorEdit, TextEditor, Position} from 'vscode';
 import * as path from "path";
@@ -129,6 +129,18 @@ class RelativePath {
         }
     }
 
+    // Check if the current extension should be excluded
+    private excludeExtensionsFor(relativeUrl: string) {
+        const currentExtension = path.extname(relativeUrl)
+        if (currentExtension === '') {
+            return false;
+        }
+
+        return this._configuration.excludExtensions.some((ext: string) => {
+            return (ext.startsWith('.') ? ext : `.${ext}`).toLowerCase() === currentExtension.toLowerCase();
+        })
+    }
+
     // Get the picked item
     private returnRelativeLink(item: QuickPickItem, editor: TextEditor): void {
         if (item) {
@@ -137,6 +149,8 @@ class RelativePath {
             let relativeUrl: string = path.relative(currentItemPath, targetPath).replace(".", "").replace(/\\/g, "/");
 
             if (this._configuration.removeExtension) {
+                relativeUrl = relativeUrl.substring(0, relativeUrl.lastIndexOf("."));
+            } else if (this.excludeExtensionsFor(relativeUrl)) {
                 relativeUrl = relativeUrl.substring(0, relativeUrl.lastIndexOf("."));
             }
             if (this._configuration.removeLeadingDot && relativeUrl.startsWith("./../")) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,7 @@ class RelativePath {
             return false;
         }
 
-        return this._configuration.excludExtensions.some((ext: string) => {
+        return this._configuration.excludedExtensions.some((ext: string) => {
             return (ext.startsWith('.') ? ext : `.${ext}`).toLowerCase() === currentExtension.toLowerCase();
         })
     }


### PR DESCRIPTION
Adds support for excluding extensions specified in the settings file. By default `.js` excluded.

Extensions in the list are case insensitive, and including the dot is optional. In the below example, files ending with `.js` and `.jsx` are excluded, but all other extensions are left in.

Edit: This closes #13 

```json
{
    "relativePath.removeLeadingDot": true,
    "relativePath.ignore": [
        "**/node_modules/**",
        "**/*.dll",
        "**/obj/**",
        "**/objd/**",
        "**/dist/**"
    ],
    "relativePath.removeExtension": false,
    "relativePath.excludedExtensions": [
        "js",
        ".JSX"
    ]
  }
```