### PR TITLE
Remove removeLeadingDot option, making it the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ The following Visual Studio Code settings are available for the RelativePath ext
 	// Excludes the extension from the relative path url (Useful for systemjs imports).
 	"relativePath.removeExtension": false,
 
-	// Removes the leading ./ character when the path is pointing to a parent folder.
-	"relativePath.removeLeadingDot": false
-
 	// An array of extensions to exclude from the relative path url (Useful for used with Webpack or when importing files of mixed types)
 	"relativePath.excludedExtensions": [
 		".js"

--- a/package.json
+++ b/package.json
@@ -60,11 +60,6 @@
                     "default": false,
                     "description": "Excludes the extension from the relative path url (Useful for systemjs imports)."
                 },
-                "relativePath.removeLeadingDot": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Removes the leading ./ character when the path is pointing to a parent folder."
-                },
                 "relativePath.excludedExtensions": {
                     "type": "array",
                     "default": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,8 @@ class RelativePath {
             } else if (this.excludeExtensionsFor(relativeUrl)) {
                 relativeUrl = relativeUrl.substring(0, relativeUrl.lastIndexOf("."));
             }
-            if (this._configuration.removeLeadingDot && relativeUrl.startsWith("./../")) {
+
+            if (relativeUrl.startsWith("./../")) {
                 relativeUrl = relativeUrl.substring(2, relativeUrl.length);
             }
 


### PR DESCRIPTION
The leading dot is redundant, and should never be there. Some IDE's
rightfully complain about this.