### PR TITLE
Added support for extending limit for quick filter through configuration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,8 +240,18 @@ class RelativePath {
             return;
         }
 
+        let extendedLimit = this._configuration.extendedLimit,
+            disableQuickFilter = true;
+
+        if (extendedLimit && this._items.length <= extendedLimit) {
+            disableQuickFilter = false;
+        }
+        else if(this._items.length <= 1000) {
+            disableQuickFilter = false;
+        }
+
         // Don't filter on too many files. Show the input search box instead
-        if (this._items.length > 1000) {
+        if (disableQuickFilter) {
             const placeHolder = `Found ${this._items.length} files. Enter the filter query. Consider adding more 'relativePath.ignore' settings.`;
             const input = window.showInputBox({placeHolder});
             input.then(val => {


### PR DESCRIPTION
Showing more than 1000 options might lead to performance issues and surely was a good check.
However, I wanted quick pick anyway despite a performance drop of ~1 sec because I had about 2K files in my project and it was fine by me.

So did all the other people in my team wanted this part of the extension become configurable.
So, a new configuration is: 
```
relativePath.extendedLimit: 2500
```
or just could be any number that a user prefers to use.

The user knows that they'll be causing the drop in performance but surely would prefer the suggestions to show up and lesser number of hits on the keyboard.

The default is still 1000. 