### PR TITLE
Fix typo in omitParts config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
                     "description": "Removes the leading ./ character when the path is pointing to a parent folder."
                 },
                 "relativePath.omitParts": {
-                    "type": "arary",
+                    "type": "array",
                     "default": [
                         "\\/index$"
                     ],


### PR DESCRIPTION
There's a typo in the omitParts configuration option. This fixes that.