### PR TITLE
fix: multi-cursor path insertion only updated the first cursor (#70)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import {
     QuickPickItemKind,
     RelativePattern,
     TextEditor,
-    TextEditorEdit,
     window,
     workspace,
     WorkspaceConfiguration,
@@ -20,6 +19,7 @@ import { getClosestMatches } from "./closest-match";
 import { shouldAddToCache } from "./glob-match";
 import { buildExcludeGlob, normalizeIncludeGlob } from "./globs";
 import { partitionByRecency, recordRecentPath } from "./recent-paths";
+import { replaceSelections } from "./replace-selections";
 import { isTruncated, resolveMaxResults } from "./search-limit";
 
 // this method is called when your extension is activated
@@ -364,17 +364,10 @@ class RelativePath {
                 });
             }
 
-            window.activeTextEditor.edit((editBuilder: TextEditorEdit) => {
-                // Get all selections
-                let selections = window.activeTextEditor.selections;
-
-                // Replace selections with relative Url.
-                selections.forEach((sel) => {
-                    editor.edit((editBuilder) => {
-                        editBuilder.replace(sel, relativeUrl);
-                    });
-                });
-            });
+            // Write every active cursor in one atomic edit. Separate edit()
+            // calls per selection are dropped by VS Code after the first,
+            // which broke multi-cursor insertions (issue #70).
+            replaceSelections(editor, relativeUrl);
         }
     }
 

--- a/src/replace-selections.ts
+++ b/src/replace-selections.ts
@@ -1,0 +1,29 @@
+// Structural interfaces so this module stays free of the `vscode` runtime
+// dependency and can be unit-tested under plain `node --test`. The real
+// `vscode.TextEditor` / `TextEditorEdit` are structurally compatible.
+interface EditBuilder {
+    replace(location: unknown, value: string): void;
+}
+
+interface EditableEditor {
+    readonly selections: ReadonlyArray<unknown>;
+    edit(callback: (editBuilder: EditBuilder) => void): Thenable<boolean>;
+}
+
+// Replace every active selection with `text` in a SINGLE atomic edit.
+//
+// VS Code allows only one active edit at a time. Firing a separate
+// editor.edit() per selection (the previous approach) meant every call after
+// the first ran against a busy/stale document and was dropped, so multi-cursor
+// insertions only updated the first cursor (issue #70). Applying all
+// replacements on one editBuilder keeps every cursor in sync.
+export function replaceSelections(
+    editor: EditableEditor,
+    text: string
+): Thenable<boolean> {
+    return editor.edit((editBuilder) => {
+        editor.selections.forEach((selection) => {
+            editBuilder.replace(selection, text);
+        });
+    });
+}

--- a/test/replace-selections.test.ts
+++ b/test/replace-selections.test.ts
@@ -1,0 +1,68 @@
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import { replaceSelections } from "../src/replace-selections";
+
+// A minimal fake editor that records how many times edit() is invoked and
+// every replace() applied to the builder. VS Code only allows one active
+// edit at a time, so the multi-cursor bug (#70) reproduces as "more than one
+// edit() call" here.
+function makeFakeEditor(selectionCount: number) {
+    const replaced: Array<{ selection: unknown; value: string }> = [];
+    let editCalls = 0;
+    const selections = Array.from({ length: selectionCount }, (_, i) => ({
+        id: i,
+    }));
+
+    const editor = {
+        selections,
+        edit(callback: (builder: any) => void): Promise<boolean> {
+            editCalls++;
+            const builder = {
+                replace(selection: unknown, value: string) {
+                    replaced.push({ selection, value });
+                },
+            };
+            callback(builder);
+            return Promise.resolve(true);
+        },
+    };
+
+    return {
+        editor,
+        replaced,
+        get editCalls() {
+            return editCalls;
+        },
+    };
+}
+
+test("replaces every selection in a single atomic edit", async () => {
+    const fake = makeFakeEditor(3);
+    const { editor, replaced } = fake;
+
+    await replaceSelections(editor as any, "./foo/bar.png");
+
+    // The heart of #70: all cursors must be written in ONE edit() call.
+    assert.strictEqual(fake.editCalls, 1);
+    assert.strictEqual(replaced.length, 3);
+    assert.deepStrictEqual(
+        replaced.map((r) => r.value),
+        ["./foo/bar.png", "./foo/bar.png", "./foo/bar.png"]
+    );
+    assert.deepStrictEqual(
+        replaced.map((r) => (r.selection as { id: number }).id),
+        [0, 1, 2]
+    );
+});
+
+test("still writes the single cursor case", async () => {
+    const fake = makeFakeEditor(1);
+    const { editor, replaced } = fake;
+
+    await replaceSelections(editor as any, "../x.ts");
+
+    assert.strictEqual(fake.editCalls, 1);
+    assert.deepStrictEqual(replaced, [
+        { selection: { id: 0 }, value: "../x.ts" },
+    ]);
+});


### PR DESCRIPTION
## Problem

Selecting text with multiple cursors and inserting a relative path only updated the **first** cursor (issue #70).

## Root cause

`returnRelativeLink` opened one `editor.edit()` and then, inside its callback, fired a **separate** `editor.edit()` for every selection in the same tick. VS Code allows only one active edit at a time, so every call after the first ran against a busy/stale document and was silently dropped.

## Fix

Extract the replacement into `replaceSelections()`, which applies every selection on a **single** `editBuilder` inside one `edit()` call. The helper uses structural typing instead of importing `vscode`, so it's covered by unit tests under the repo's `node --test` harness (matching the other pure modules).

## Tests

- New `test/replace-selections.test.ts`: asserts exactly one `edit()` call with one replacement per cursor, plus the single-cursor case.
- Written test-first (verified failing, then passing). Full suite: 33 passing.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)