### PR TITLE
Remove redundant activationEvents declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     ],
     "license": "MIT",
     "displayName": "Relative Path",
-    "activationEvents": [
-        "onCommand:extension.relativePath"
-    ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [


### PR DESCRIPTION
VS Code 1.74 begins handling the onCommand event implicitly, and the entire array can be removed.